### PR TITLE
Return a single IP address String from getIP, rather than a Sequence

### DIFF
--- a/Payload_Type/Nimplant/agent_code/utils/checkin.nim
+++ b/Payload_Type/Nimplant/agent_code/utils/checkin.nim
@@ -60,7 +60,7 @@ proc getPID: int =
     result = getCurrentProcessId()
 
 proc getIP(host: string): string = 
-    result = $(nativesockets.getHostByName(host).addrList)
+    result = $(nativesockets.getHostByName(host).addrList[0])
 
 proc getHostName*(): string = 
     result = nativesockets.getHostname()


### PR DESCRIPTION
Will look like `127.0.1.1` rather than `@["127.0.1.1"]` in Callback view. Compare these two callbacks, number 29 comes from a payload that was built before applying these changes, and number 30 was built after:

<img width="615" alt="Screen Shot 2021-01-29 at 9 03 00 PM" src="https://user-images.githubusercontent.com/66427/106347807-100ecb00-6276-11eb-88db-a3fdf44bfc55.png">
